### PR TITLE
v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev3",
+  "version": "2.1.0-dev4",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev1",
+  "version": "2.1.0-dev2",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev2",
+  "version": "2.1.0-dev3",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev7",
+  "version": "2.1.0-dev8",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev8",
+  "version": "2.1.0-dev9",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.0.2",
+  "version": "2.1.0-dev0",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev4",
+  "version": "2.1.0-dev5",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev5",
+  "version": "2.1.0-dev6",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev9",
+  "version": "2.1.0",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev0",
+  "version": "2.1.0-dev1",
   "type": "module",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sharc-js",
   "private": false,
-  "version": "2.1.0-dev6",
+  "version": "2.1.0-dev7",
   "type": "module",
   "files": [
     "dist",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { Stage } from "./sharc/Stage";
 import { OffscreenStage } from "./sharc/async_stages/OffscreenStage";
 import { tests } from "./tests";
 
-const useOffscreen = false;
+const useOffscreen = true;
 
 let framerate = 60;
 
@@ -23,6 +23,7 @@ tests.forEach(test => {
     detailsElement.addEventListener("toggle", () => {
         stage?.stop();
         if (detailsElement.open) {
+            localStorage.setItem("lastTest", test.name);
             document.querySelectorAll("details").forEach(details => {
                 if (details !== detailsElement) {
                     details.removeAttribute("open");
@@ -45,3 +46,5 @@ tests.forEach(test => {
         }
     });
 });
+
+localStorage.getItem("lastTest") && document.getElementById(localStorage.getItem("lastTest")!)?.parentElement?.setAttribute("open", "");

--- a/src/sharc/Channels.ts
+++ b/src/sharc/Channels.ts
@@ -167,6 +167,6 @@ export class Channel<Properties> {
     }
 
     public get animations(): AnimationPackage<Properties>[] {
-        return [...this.queue];
+        return this.queue.map((pkg) => { return { ...pkg }; });
     }
 }

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -690,6 +690,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
             const transformedPos = ctx.getTransform().inverse().transformPoint(translatedPoint) as PositionType;
             const transformationMatrix = ctx.getTransform();
             self.lastPointerPosition = transformedPos;
+            self.lastTransformationMatrix = transformationMatrix;
             const callback = function (pointerId?: number) {
                 ctx.save();
                 ctx.setTransform(

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -565,7 +565,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
             (child as Sprite).events = this.events;
             child.draw(ctx, undefined, false);
         });
-        if (!this.handlePointerEvents(ctx)) {
+        if (this.events!.stage && !this.handlePointerEvents(ctx, this.events!.stage)) {
             ctx.restore();
         }
         if (this.pointerId !== undefined) {
@@ -576,7 +576,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
         }
     }
 
-    public handlePointerEvents(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D): boolean {
+    public handlePointerEvents(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, stage: Stage): boolean {
         let ctxRestored = false;
 
         if (this.events === undefined) return false;
@@ -617,7 +617,8 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 this.events.move?.translatedPoint ??
                     this.events.down?.translatedPoint ??
                     this.events.up!.translatedPoint,
-                this.events.move?.event ?? this.events.down?.event ?? this.events.up!.event
+                this.events.move?.event ?? this.events.down?.event ?? this.events.up!.event,
+                stage
             ]);
             this.hovered = true;
         } else if (!pointIsInPath && this.hovered) {
@@ -628,7 +629,8 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 callAndPrune(this.eventListeners, "hoverEnd", [
                     this,
                     unHoverEvent!.translatedPoint,
-                    unHoverEvent!.event
+                    unHoverEvent!.event,
+                    stage
                 ]);
             }
             this.hovered = false;
@@ -640,14 +642,14 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 this.eventListeners.keydown.length > 0 &&
                 this.events.stage!.keyTarget === this.name
             ) {
-                callAndPrune(this.eventListeners, "keydown", [this, this.events.keydown]);
+                callAndPrune(this.eventListeners, "keydown", [this, this.events.keydown, stage]);
             }
             if (
                 this.events?.keyup &&
                 this.eventListeners.keyup.length > 0 &&
                 this.events.stage!.keyTarget === this.name
             ) {
-                callAndPrune(this.eventListeners, "keyup", [this, this.events.keyup]);
+                callAndPrune(this.eventListeners, "keyup", [this, this.events.keyup, stage]);
             }
 
             if (
@@ -656,7 +658,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 pointIsInPath &&
                 this.events.stage!.scrollTarget === this.name
             ) {
-                callAndPrune(this.eventListeners, "scroll", [this, this.events.scroll]);
+                callAndPrune(this.eventListeners, "scroll", [this, this.events.scroll, stage]);
             }
         }
 
@@ -681,7 +683,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                     transformationMatrix.e,
                     transformationMatrix.f
                 );
-                callAndPrune(self.eventListeners, listener!, [self, transformedPos, event]);
+                callAndPrune(self.eventListeners, listener!, [self, transformedPos, event, stage]);
                 if (pointerId !== undefined) {
                     self.pointerId = pointerId;
                 }

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -708,7 +708,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 ctx.restore();
                 ctxRestored = true;
                 registerCallback(ctx, this.events.move, this.root, this, "drag", this.pointerId);
-            } else {
+            } else if (this.pointerId !== undefined) {
                 registerCallback(ctx, this.events.move, this.root, this, undefined);
             }
         }

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -432,7 +432,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
     }
 
     protected pointerId?: number = undefined;
-    private lastClickPosition?: PositionType = undefined;
+    private lastPointerPosition?: PositionType = undefined;
     protected hovered = false;
 
     private eventListeners: SpriteEventListeners<this, Properties & HiddenProperties> = {
@@ -573,7 +573,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
             this.rootPointerEventCallback();
         }
         if (this.events!.stage && this.pointerId !== undefined) {
-            callAndPrune(this.eventListeners, "hold", [this, this.lastClickPosition!, this.events!.move?.event, this.events!.stage]);
+            callAndPrune(this.eventListeners, "hold", [this, this.lastPointerPosition!, this.events!.move?.event, this.events!.stage]);
         }
     }
 
@@ -684,7 +684,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                     transformationMatrix.e,
                     transformationMatrix.f
                 );
-                self.lastClickPosition = transformedPos;
+                self.lastPointerPosition = transformedPos;
                 callAndPrune(self.eventListeners, listener!, [self, transformedPos, event, stage]);
                 if (pointerId !== undefined) {
                     self.pointerId = pointerId;
@@ -692,11 +692,12 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 ctx.restore();
             };
             if (listener === undefined) {
-                (root as Sprite).rootPointerEventCallback = function (pointerId?: number) {
+                (root as Sprite).rootPointerEventCallback = function (pointerId?: number, translatedPoint?: PositionType) {
                     if (pointerId !== undefined) {
                         self.pointerId = pointerId;
                     }
-                }.bind(this, pointerId);
+                    self.lastPointerPosition = translatedPoint;
+                }.bind(this, pointerId, transformedPos);
             } else {
                 (root as Sprite).rootPointerEventCallback = callback.bind(this, pointerId);
             }
@@ -707,6 +708,8 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 ctx.restore();
                 ctxRestored = true;
                 registerCallback(ctx, this.events.move, this.root, this, "drag", this.pointerId);
+            } else {
+                registerCallback(ctx, this.events.move, this.root, this, undefined);
             }
         }
         if (this.events.up) {

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -432,6 +432,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
     }
 
     protected pointerId?: number = undefined;
+    private lastClickPosition?: PositionType = undefined;
     protected hovered = false;
 
     private eventListeners: SpriteEventListeners<this, Properties & HiddenProperties> = {
@@ -568,11 +569,11 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
         if (this.events!.stage && !this.handlePointerEvents(ctx, this.events!.stage)) {
             ctx.restore();
         }
-        if (this.pointerId !== undefined) {
-            callAndPrune(this.eventListeners, "hold", [this]);
-        }
         if (isRoot) {
             this.rootPointerEventCallback();
+        }
+        if (this.events!.stage && this.pointerId !== undefined) {
+            callAndPrune(this.eventListeners, "hold", [this, this.lastClickPosition!, this.events!.move?.event, this.events!.stage]);
         }
     }
 
@@ -683,6 +684,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                     transformationMatrix.e,
                     transformationMatrix.f
                 );
+                self.lastClickPosition = transformedPos;
                 callAndPrune(self.eventListeners, listener!, [self, transformedPos, event, stage]);
                 if (pointerId !== undefined) {
                     self.pointerId = pointerId;

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -724,6 +724,8 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 ctxRestored = true;
                 registerCallback(ctx, this.events.move, this.root, this, "drag", this.pointerId);
             } else if (this.pointerId !== undefined) {
+                ctx.restore();
+                ctxRestored = true;
                 this.lastPointerPosition = ctx.getTransform().inverse().transformPoint(this.events.move.translatedPoint);
                 this.lastTransformationMatrix = ctx.getTransform();
             }

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -722,6 +722,8 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 ctx.restore();
                 ctxRestored = true;
                 registerCallback(ctx, this.events.move, this.root, this, "drag", this.pointerId);
+            } else if (this.pointerId !== undefined) {
+                this.lastPointerPosition = ctx.getTransform().inverse().transformPoint(this.events.move.translatedPoint);
             }
         }
         if (this.events.up) {

--- a/src/sharc/Sprite.ts
+++ b/src/sharc/Sprite.ts
@@ -725,6 +725,7 @@ export abstract class Sprite<DetailsType = any, Properties = object, HiddenPrope
                 registerCallback(ctx, this.events.move, this.root, this, "drag", this.pointerId);
             } else if (this.pointerId !== undefined) {
                 this.lastPointerPosition = ctx.getTransform().inverse().transformPoint(this.events.move.translatedPoint);
+                this.lastTransformationMatrix = ctx.getTransform();
             }
         }
         if (this.events.up) {

--- a/src/sharc/Stage.ts
+++ b/src/sharc/Stage.ts
@@ -119,7 +119,7 @@ export class Stage<RootDetailsType = any> {
                 (this.rootStyle === "centered" ? this.height! / 2 : 0)) *
                 (this.rootStyle === "centered" ? -1 : 1)
         );
-        callAndPrune(this.eventListeners, "click", [this, position, e]);
+        callAndPrune(this.eventListeners, "click", [this, position, e, this]);
         this.drawEvents.down = { event: e, translatedPoint: this.positionOnCanvas(this.canvas!, e) };
         this.canvas?.focus && this.canvas.focus();
     }
@@ -136,7 +136,7 @@ export class Stage<RootDetailsType = any> {
                 (this.rootStyle === "centered" ? this.height! / 2 : 0)) *
                 (this.rootStyle === "centered" ? -1 : 1)
         );
-        callAndPrune(this.eventListeners, "release", [this, position, e]);
+        callAndPrune(this.eventListeners, "release", [this, position, e, this]);
         this.drawEvents.up = { event: e, translatedPoint: this.positionOnCanvas(this.canvas!, e) };
     }
 
@@ -152,7 +152,7 @@ export class Stage<RootDetailsType = any> {
                 (this.rootStyle === "centered" ? this.height! / 2 : 0)) *
                 (this.rootStyle === "centered" ? -1 : 1)
         );
-        callAndPrune(this.eventListeners, "move", [this, position, e]);
+        callAndPrune(this.eventListeners, "move", [this, position, e, this]);
         this.drawEvents.move = { event: e, translatedPoint: this.positionOnCanvas(this.canvas!, e) };
     }
 
@@ -161,7 +161,7 @@ export class Stage<RootDetailsType = any> {
             return;
         }
         e.preventDefault();
-        callAndPrune(this.eventListeners, "keydown", [this, e]);
+        callAndPrune(this.eventListeners, "keydown", [this, e, this]);
         this.drawEvents.keydown = e;
     }
 
@@ -170,7 +170,7 @@ export class Stage<RootDetailsType = any> {
             return;
         }
         e.preventDefault();
-        callAndPrune(this.eventListeners, "keyup", [this, e]);
+        callAndPrune(this.eventListeners, "keyup", [this, e, this]);
         this.drawEvents.keyup = e;
     }
 
@@ -178,7 +178,7 @@ export class Stage<RootDetailsType = any> {
         if (!this.active) {
             return;
         }
-        callAndPrune(this.eventListeners, "scroll", [this, e]);
+        callAndPrune(this.eventListeners, "scroll", [this, e, this]);
         this.drawEvents.scroll = e;
         e.preventDefault();
     }

--- a/src/sharc/async_stages/OffscreenStage.ts
+++ b/src/sharc/async_stages/OffscreenStage.ts
@@ -167,7 +167,7 @@ export class OffscreenStage<DetailsType = any, MessageType = any> extends Stage<
             AsyncMessage<MessageType>
         >
     >(event: E, callback: AsyncStageEventListeners<this, AsyncMessage<MessageType>>[E][0]): this {
-        this.eventListeners[event as "click"].push(callback as unknown as PointerEventCallback<this>);
+        this.eventListeners[event as "click"].push(callback as unknown as PointerEventCallback<this, this>);
         return this;
     }
 
@@ -192,7 +192,7 @@ export class OffscreenStage<DetailsType = any, MessageType = any> extends Stage<
             return this;
         }
         this.eventListeners[event as "click"] = this.eventListeners[event as "click"].filter(
-            cb => cb !== (callback as unknown as PointerEventCallback<this>)
+            cb => cb !== (callback as unknown as PointerEventCallback<this, this>)
         );
         return this;
     }

--- a/src/sharc/async_stages/WorkerStage.ts
+++ b/src/sharc/async_stages/WorkerStage.ts
@@ -67,7 +67,7 @@ export class WorkerStage<DetailsType = any, MessageType = any> extends Stage<Det
             AsyncMessage<MessageType>
         >
     >(event: E, callback: AsyncStageEventListeners<this, AsyncMessage<MessageType>>[E][0]): this {
-        this.eventListeners[event as "click"].push(callback as unknown as PointerEventCallback<this>);
+        this.eventListeners[event as "click"].push(callback as unknown as PointerEventCallback<this, this>);
         return this;
     }
 
@@ -92,7 +92,7 @@ export class WorkerStage<DetailsType = any, MessageType = any> extends Stage<Det
             return this;
         }
         this.eventListeners[event as "click"] = this.eventListeners[event as "click"].filter(
-            cb => cb !== (callback as unknown as PointerEventCallback<this>)
+            cb => cb !== (callback as unknown as PointerEventCallback<this, this>)
         );
         return this;
     }
@@ -135,6 +135,7 @@ export class WorkerStage<DetailsType = any, MessageType = any> extends Stage<Det
         const e = event.data;
         switch (e.type) {
             case "init":
+                this.canvas!.width = e.width;
                 this.canvas!.height = e.height;
                 this.canvas!.offsetLeft = 0;
                 this.canvas!.offsetTop = 0;
@@ -175,7 +176,8 @@ export class WorkerStage<DetailsType = any, MessageType = any> extends Stage<Det
                             (down.translatedPoint.y - (this.rootStyle === "centered" ? this.canvas!.height / 2 : 0)) *
                             (this.rootStyle === "centered" ? -1 : 1)
                     },
-                    down.event
+                    down.event,
+                    this
                 ],
                 this.sendErrorString.bind(this)
             );
@@ -191,7 +193,8 @@ export class WorkerStage<DetailsType = any, MessageType = any> extends Stage<Det
                             (up.translatedPoint.y - (this.rootStyle === "centered" ? this.canvas!.height / 2 : 0)) *
                             (this.rootStyle === "centered" ? -1 : 1)
                     },
-                    up.event
+                    up.event,
+                    this
                 ],
                 this.sendErrorString.bind(this)
             );
@@ -207,13 +210,14 @@ export class WorkerStage<DetailsType = any, MessageType = any> extends Stage<Det
                             (move.translatedPoint.y - (this.rootStyle === "centered" ? this.canvas!.height / 2 : 0)) *
                             (this.rootStyle === "centered" ? -1 : 1)
                     },
-                    move.event
+                    move.event,
+                    this
                 ],
                 this.sendErrorString.bind(this)
             );
-        keydown && callAndPrune(this.eventListeners, "keydown", [this, keydown], this.sendErrorString.bind(this));
-        keyup && callAndPrune(this.eventListeners, "keyup", [this, keyup], this.sendErrorString.bind(this));
-        scroll && callAndPrune(this.eventListeners, "scroll", [this, scroll], this.sendErrorString.bind(this));
+        keydown && callAndPrune(this.eventListeners, "keydown", [this, keydown, this], this.sendErrorString.bind(this));
+        keyup && callAndPrune(this.eventListeners, "keyup", [this, keyup, this], this.sendErrorString.bind(this));
+        scroll && callAndPrune(this.eventListeners, "scroll", [this, scroll, this], this.sendErrorString.bind(this));
         if (
             this.resetKeyTargetOnClick &&
             this.drawEvents.up &&

--- a/src/sharc/sprite_definitions/Label.ts
+++ b/src/sharc/sprite_definitions/Label.ts
@@ -1,4 +1,4 @@
-import { ColorType, PositionType } from "../types/Common";
+import { BoundsType, ColorType, PositionType } from "../types/Common";
 import { Corners, Position, Color } from "../Utils";
 import { OmitBaseProps, LabelProperties, HiddenLabelProperties, StrokeType, RadiusType } from "../types/Sprites";
 import StrokeableSprite from "./StrokeableSprite";
@@ -27,6 +27,11 @@ export default class LabelSprite<DetailsType = any>
         this.backgroundRadius = props.backgroundRadius ?? [5];
         this.padding = props.padding ?? 10;
         this.textStroke = props.textStroke ?? null;
+        const bounds = this.calculateBounds(new OffscreenCanvas(0, 0).getContext("2d")!);
+        this.x1 = bounds.x1;
+        this.y1 = bounds.y1;
+        this.x2 = bounds.x2;
+        this.y2 = bounds.y2;
     }
 
     // NORMAL PROPERTIES
@@ -59,6 +64,83 @@ export default class LabelSprite<DetailsType = any>
         this.positionY = value.y;
     }
 
+    // CALCULATED PROPERTIES
+    public get bounds() {
+        return this.calculateBounds(new OffscreenCanvas(0, 0).getContext("2d")!);
+    }
+    public set bounds(_value: BoundsType) {
+        throw new Error("Polygon bounds cannot be set");
+    }
+
+    public get center() {
+        return Position((this.x1 + this.x2) / 2, (this.y1 + this.y2) / 2);
+    }
+    public set center(value: PositionType) {
+        const center = this.center;
+        const dx = value.x - center.x;
+        const dy = value.y - center.y;
+        this.position = Position(this.positionX + dx, this.positionY + dy);
+    }
+
+    public get corner1() {
+        return Position(this.x1, this.y1);
+    }
+    public set corner1(value: PositionType) {
+        const corner1 = this.corner1;
+        const dx = value.x - corner1.x;
+        const dy = value.y - corner1.y;
+        this.position = Position(this.positionX + dx, this.positionY + dy);
+    }
+
+    public get corner2() {
+        return Position(this.x2, this.y2);
+    }
+    public set corner2(value: PositionType) {
+        const corner2 = this.corner2;
+        const dx = value.x - corner2.x;
+        const dy = value.y - corner2.y;
+        this.position = Position(this.positionX + dx, this.positionY + dy);
+    }
+
+    public get width() {
+        return Math.abs(this.x2 - this.x1);
+    }
+    public set width(_value: number) {
+        throw new Error("Text width cannot be set");
+    }
+
+    public get height() {
+        return Math.abs(this.y2 - this.y1);
+    }
+    public set height(_value: number) {
+        throw new Error("Text height cannot be set");
+    }
+
+
+    private calculateBounds(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D) {
+        ctx.font = `${this.bold ? "bold " : ""}${this.italic ? "italic " : ""}${this.fontSize}px ${this.font}`;
+        ctx.textBaseline = this.textBaseline;
+        ctx.direction = this.textDirection;
+        const metrics = ctx.measureText(this.text);
+        const width = metrics.width;
+        const height = this.fontSize;
+        const xOffset = 
+            !this.positionIsCenter ?
+                (this.textAlign === "start" || this.textAlign === "left") ? 0 :
+                (this.textAlign === "end" || this.textAlign === "right") ? width :
+                this.textAlign === "center" ? width / 2 :
+                0 :
+            0;
+        const yOffset = this.positionIsCenter ? 0 : ((this.root as LabelSprite).stage?.rootStyle === "centered" ? -height : 0);
+        return {
+            x1: this.positionX + (this.positionIsCenter ? -width / 2 : 0) - xOffset - this.padding,
+            y1: this.positionY + (this.positionIsCenter ? -height / 2 : 0) + yOffset - this.padding,
+            x2: this.positionX + (this.positionIsCenter ? width / 2 : width) - xOffset + this.padding,
+            y2: this.positionY + (this.positionIsCenter ? height / 2 : height) + yOffset + this.padding
+        };
+    }
+
+
     public get backgroundColor(): ColorType {
         return Color(this.backgroundRed, this.backgroundGreen, this.backgroundBlue, this.backgroundAlpha);
     }
@@ -73,25 +155,11 @@ export default class LabelSprite<DetailsType = any>
         if ((this.root as LabelSprite).stage?.rootStyle === "centered") {
             this.scaleY *= -1;
         }
-        ctx.font = `${this.bold ? "bold " : ""}${this.italic ? "italic " : ""}${this.fontSize}px ${this.font}`;
-        ctx.textAlign = this.textAlign;
-        ctx.textBaseline = this.textBaseline;
-        ctx.direction = this.textDirection;
-        const metrics = ctx.measureText(this.text);
-        const width = metrics.width;
-        const ascent = metrics.fontBoundingBoxAscent;
-        const height = this.fontSize;
-        if (this.positionIsCenter) {
-            this.x1 = this.positionX - width / 2 - this.padding;
-            this.y1 = this.positionY - ascent / 2 - this.padding;
-            this.x2 = this.positionX + width / 2 + this.padding;
-            this.y2 = this.positionY + ascent / 2 + this.padding;
-        } else {
-            this.x1 = this.positionX - this.padding;
-            this.y1 = this.positionY - this.padding;
-            this.x2 = this.positionX + width + this.padding;
-            this.y2 = this.positionY + height + this.padding;
-        }
+        const bounds = this.calculateBounds(ctx);
+        this.x1 = bounds.x1;
+        this.y1 = bounds.y1;
+        this.x2 = bounds.x2;
+        this.y2 = bounds.y2;
         super.draw(ctx, {
             text: this.text,
             position: Position(this.positionX, this.positionY),

--- a/src/sharc/types/Events.ts
+++ b/src/sharc/types/Events.ts
@@ -3,15 +3,16 @@ import { PositionType } from "./Common";
 import { DEFAULT_PROPERTIES, HIDDEN_SHAPE_PROPERTIES } from "./Sprites";
 import { PrivateAnimationType } from "./Animation";
 
-export type PointerEventCallback<CallerType> = (
+export type PointerEventCallback<CallerType, StageType = Stage> = (
     caller: CallerType,
     translatedPoint: PositionType,
-    event: PointerEvent
+    event: PointerEvent,
+    stage: StageType
 ) => boolean | 0 | 1 | void;
 
-export type ScrollEventCallback<CallerType> = (caller: CallerType, event: WheelEvent) => boolean | 0 | 1 | void;
+export type ScrollEventCallback<CallerType, StageType = Stage> = (caller: CallerType, event: WheelEvent, stage: StageType) => boolean | 0 | 1 | void;
 
-export type KeyboardEventCallback<CallerType> = (caller: CallerType, event: KeyboardEvent) => boolean | 0 | 1 | void;
+export type KeyboardEventCallback<CallerType, StageType = Stage> = (caller: CallerType, event: KeyboardEvent, stage: StageType) => boolean | 0 | 1 | void;
 
 export type PositionedPointerEvent = {
     event: PointerEvent;
@@ -62,12 +63,12 @@ export type SpriteEventListeners<CallerType = undefined, Properties = any> = {
 };
 
 export type StageEventListeners<CallerType = Stage> = {
-    click: PointerEventCallback<CallerType>[];
-    release: PointerEventCallback<CallerType>[];
-    move: PointerEventCallback<CallerType>[];
-    scroll: ScrollEventCallback<CallerType>[];
-    keydown: KeyboardEventCallback<CallerType>[];
-    keyup: KeyboardEventCallback<CallerType>[];
+    click: PointerEventCallback<CallerType, CallerType>[];
+    release: PointerEventCallback<CallerType, CallerType>[];
+    move: PointerEventCallback<CallerType, CallerType>[];
+    scroll: ScrollEventCallback<CallerType, CallerType>[];
+    keydown: KeyboardEventCallback<CallerType, CallerType>[];
+    keyup: KeyboardEventCallback<CallerType, CallerType>[];
     beforeDraw: StageEventCallback<CallerType, CallerType>[];
 };
 

--- a/src/sharc/types/Events.ts
+++ b/src/sharc/types/Events.ts
@@ -51,7 +51,7 @@ export type SpriteEventListeners<CallerType = undefined, Properties = any> = {
     release: PointerEventCallback<CallerType>[];
     hover: PointerEventCallback<CallerType>[];
     hoverEnd: PointerEventCallback<CallerType>[];
-    hold: ((sprite: CallerType) => boolean | 0 | 1 | void)[];
+    hold: ((sprite: CallerType, translatedPoint: PositionType, event: PointerEvent|undefined, stage: Stage) => boolean | 0 | 1 | void)[];
     keydown: KeyboardEventCallback<CallerType>[];
     keyup: KeyboardEventCallback<CallerType>[];
     scroll: ScrollEventCallback<CallerType>[];

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -303,7 +303,7 @@ export const tests: Test[] = [
                 new TextSprite<number>({
                     text: `Counting up to ${max}: 0`,
                     fontSize: 50,
-                    position: { x: 1175, y: 725 },
+                    position: { x: 1175 , y: 725 },
                     textAlign: "right",
                     details: 0
                 })
@@ -382,6 +382,48 @@ export const tests: Test[] = [
                     }
                 ],
                 { loop: true }
+            );
+        }
+    },
+    {
+        name: "text-bounds",
+        apply: (stage: Stage | WorkerStage<any, string>) => {
+            const text = new LabelSprite<string>({
+                text: "Hello, world!!!",
+                fontSize: 50,
+                position: { x: 500, y: 100 },
+                color: Colors.Red,
+                bold: true,
+                textAlign: "right",
+                backgroundColor: Colors.DarkGray,
+                backgroundRadius: [20],
+                padding: 10,
+            });
+            console.log(text.bounds);
+            const outline = new Rect({
+                color: Colors.None,
+                stroke: {
+                    lineDash: 10,
+                    lineDashGap: 5,
+                    color: Colors.Black,
+                }
+            });
+            text.on("beforeDraw", (sprite, frame) => {
+                const property = 
+                    frame % 120 === 1 ? "center" :
+                    frame % 120 === 41 ? "corner1" :
+                    frame % 120 === 81 ? "corner2" :
+                "";
+                if (!property) {
+                    return;
+                }
+                sprite[property] = { x: 500, y: 100 };
+                outline.bounds = sprite.bounds;
+            });
+            stage.root.addChildren(outline, text,
+                new Ellipse({
+                    center: { x: 500, y: 100 },
+                })
             );
         }
     }


### PR DESCRIPTION
Fix placement of TextSprite and LabelSprite when positionIsCenter is false
Make "center" getters and setters functional on TextSprite and LabelSprite
Add Stage parameter to PointerEvent, KeyboardEvent, and WheelEvent listeners
Fix bug where WorkerStage width property would not be immediately updated
Keep track of last known position from "click", "release", and "drag" events for use in "hold" event listener
Return a copy of animations from channel.animations instead of their references